### PR TITLE
Support custom CryptographyClientOptions for the CryptographyClient

### DIFF
--- a/RSAKeyVaultProvider/ECDsaKeyVaultExtensions.cs
+++ b/RSAKeyVaultProvider/ECDsaKeyVaultExtensions.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography.X509Certificates;
 
 using Azure.Core;
 using Azure.Security.KeyVault.Keys;
+using Azure.Security.KeyVault.Keys.Cryptography;
 
 namespace RSAKeyVaultProvider
 {
@@ -19,7 +20,7 @@ namespace RSAKeyVaultProvider
         /// <param name="keyId"></param>
         /// <param name="key"></param>
         /// <returns></returns>
-        public static ECDsa Create(TokenCredential credential, Uri keyId, JsonWebKey key)
+        public static ECDsa Create(TokenCredential credential, Uri keyId, JsonWebKey key, CryptographyClientOptions options = null)
         {
             if (credential is null)
                 throw new ArgumentNullException(nameof(credential));
@@ -30,7 +31,7 @@ namespace RSAKeyVaultProvider
             if (key is null)
                 throw new ArgumentNullException(nameof(key));
 
-            return new ECDsaKeyVault(new KeyVaultContext(credential, keyId, key));
+            return new ECDsaKeyVault(new KeyVaultContext(credential, keyId, key, options));
         }
 
         /// <summary>
@@ -40,7 +41,7 @@ namespace RSAKeyVaultProvider
         /// <param name="keyId"></param>
         /// <param name="publicCertificate"></param>
         /// <returns></returns>
-        public static ECDsa Create(TokenCredential credential, Uri keyId, X509Certificate2 publicCertificate)
+        public static ECDsa Create(TokenCredential credential, Uri keyId, X509Certificate2 publicCertificate, CryptographyClientOptions options = null)
         {
             if (credential is null)
                 throw new ArgumentNullException(nameof(credential));
@@ -51,7 +52,7 @@ namespace RSAKeyVaultProvider
             if (publicCertificate is null)
                 throw new ArgumentNullException(nameof(publicCertificate));
 
-            return new ECDsaKeyVault(new KeyVaultContext(credential, keyId, publicCertificate));
+            return new ECDsaKeyVault(new KeyVaultContext(credential, keyId, publicCertificate, options));
         }
     }
 }

--- a/RSAKeyVaultProvider/KeyVaultContext.cs
+++ b/RSAKeyVaultProvider/KeyVaultContext.cs
@@ -18,20 +18,20 @@ namespace RSAKeyVaultProvider
         /// <summary>
         /// Creates a new Key Vault context.
         /// </summary>
-        public KeyVaultContext(TokenCredential credential, Uri keyId, JsonWebKey key)
+        public KeyVaultContext(TokenCredential credential, Uri keyId, JsonWebKey key, CryptographyClientOptions options = null)
         {            
             KeyIdentifier = keyId ?? throw new ArgumentNullException(nameof(keyId));
             Key = key ?? throw new ArgumentNullException(nameof(key));
 
 
-            cryptographyClient = new CryptographyClient(keyId, credential);
+            cryptographyClient = new CryptographyClient(keyId, credential, options);
             Certificate = null;            
         }
 
         /// <summary>
         /// Creates a new Key Vault context.
         /// </summary>
-        public KeyVaultContext(TokenCredential credential, Uri keyId, X509Certificate2 publicCertificate)
+        public KeyVaultContext(TokenCredential credential, Uri keyId, X509Certificate2 publicCertificate, CryptographyClientOptions options = null)
         {
             if (credential is null)
             {
@@ -41,7 +41,7 @@ namespace RSAKeyVaultProvider
             Certificate = publicCertificate ?? throw new ArgumentNullException(nameof(publicCertificate));
             KeyIdentifier = keyId ?? throw new ArgumentNullException(nameof(keyId));
 
-            cryptographyClient = new CryptographyClient(keyId, credential);
+            cryptographyClient = new CryptographyClient(keyId, credential, options);
 
             string algorithm = publicCertificate.GetKeyAlgorithm();
 

--- a/RSAKeyVaultProvider/RSAKeyVaultExtensions.cs
+++ b/RSAKeyVaultProvider/RSAKeyVaultExtensions.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography.X509Certificates;
 
 using Azure.Core;
 using Azure.Security.KeyVault.Keys;
+using Azure.Security.KeyVault.Keys.Cryptography;
 
 namespace RSAKeyVaultProvider
 {
@@ -19,7 +20,7 @@ namespace RSAKeyVaultProvider
         /// <param name="keyId"></param>
         /// <param name="key"></param>
         /// <returns></returns>
-        public static RSA Create(TokenCredential credential, Uri keyId, JsonWebKey key)
+        public static RSA Create(TokenCredential credential, Uri keyId, JsonWebKey key, CryptographyClientOptions options = null)
         {
             if (credential == null)
             {
@@ -36,7 +37,7 @@ namespace RSAKeyVaultProvider
                 throw new ArgumentNullException(nameof(key));
             }
 
-            return new RSAKeyVault(new KeyVaultContext(credential, keyId, key));
+            return new RSAKeyVault(new KeyVaultContext(credential, keyId, key, options));
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace RSAKeyVaultProvider
         /// <param name="keyId"></param>
         /// <param name="publicCertificate"></param>
         /// <returns></returns>
-        public static RSA Create(TokenCredential credential, Uri keyId, X509Certificate2 publicCertificate)
+        public static RSA Create(TokenCredential credential, Uri keyId, X509Certificate2 publicCertificate, CryptographyClientOptions options = null)
         {
             if (credential == null)
             {
@@ -63,7 +64,7 @@ namespace RSAKeyVaultProvider
                 throw new ArgumentNullException(nameof(publicCertificate));
             }
 
-            return new RSAKeyVault(new KeyVaultContext(credential, keyId, publicCertificate));
+            return new RSAKeyVault(new KeyVaultContext(credential, keyId, publicCertificate, options));
         }
     }
 }


### PR DESCRIPTION
Let the consumer ability to use a custom CryptographyClientOptions (using HttpClientTransport, for example) for the CryptographyClient